### PR TITLE
feat(redis): disable JMX monitoring in Redis configuration

### DIFF
--- a/src/main/java/com/chumore/config/RedisConfig.java
+++ b/src/main/java/com/chumore/config/RedisConfig.java
@@ -33,7 +33,9 @@ public class RedisConfig {
 		config.setMaxTotal(maxTotal);
 		config.setMaxIdle(maxIdle);
 		config.setMaxWaitMillis(maxWaitMillis);
-		
+
+		config.setJmxEnabled(false);
+
 		return new JedisPool(config, redisHost, redisPort);
 	}
 	


### PR DESCRIPTION

Added `config.setJmxEnabled(false)` to the Redis pool configuration in `RedisConfig.java`. 
This change disables JMX monitoring to reduce potential performance overhead 
and improve runtime efficiency for Redis clients.